### PR TITLE
Feature/external entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A stand alone artifactory module has been provided as a stand alone module to ca
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_api_gateway_stage_name"></a> [api\_gateway\_stage\_name](#input\_api\_gateway\_stage\_name) | Stage name for the api gateway deployment | `string` | `"test"` | no |
 | <a name="input_application_env_vars"></a> [application\_env\_vars](#input\_application\_env\_vars) | Map of environment variables required by any function in the application. | `map(any)` | `{}` | no |
 | <a name="input_application_memory"></a> [application\_memory](#input\_application\_memory) | Memory allocated to all functions in the application. Defaults to `128`. | `number` | `128` | no |
 | <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Repo name of the lambda application. | `string` | n/a | yes |
@@ -85,7 +86,7 @@ A stand alone artifactory module has been provided as a stand alone module to ca
 | <a name="input_create_rds_instance"></a> [create\_rds\_instance](#input\_create\_rds\_instance) | Controls if an RDS instance should be provisioned and integrated with the Kubernetes deployment. | `bool` | `false` | no |
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Controls if an S3 bucket should be provisioned | `bool` | `false` | no |
 | <a name="input_datastore_tags"></a> [datastore\_tags](#input\_datastore\_tags) | Additional tags to add to all datastore resources | `map(string)` | `{}` | no |
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The name of the domain | `any` | n/a | yes |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The custom domain name for api gateway that points to lambda application | `string` | n/a | yes |
 | <a name="input_dynamodb_attributes"></a> [dynamodb\_attributes](#input\_dynamodb\_attributes) | Additional DynamoDB attributes in the form of a list of mapped values | `list` | `[]` | no |
 | <a name="input_dynamodb_autoscale_max_read_capacity"></a> [dynamodb\_autoscale\_max\_read\_capacity](#input\_dynamodb\_autoscale\_max\_read\_capacity) | DynamoDB autoscaling max read capacity | `number` | `20` | no |
 | <a name="input_dynamodb_autoscale_max_write_capacity"></a> [dynamodb\_autoscale\_max\_write\_capacity](#input\_dynamodb\_autoscale\_max\_write\_capacity) | DynamoDB autoscaling max write capacity | `number` | `20` | no |
@@ -109,7 +110,7 @@ A stand alone artifactory module has been provided as a stand alone module to ca
 | <a name="input_dynamodb_tags"></a> [dynamodb\_tags](#input\_dynamodb\_tags) | Additional tags (e.g map(`BusinessUnit`,`XYX`) | `map` | `{}` | no |
 | <a name="input_dynamodb_ttl_attribute"></a> [dynamodb\_ttl\_attribute](#input\_dynamodb\_ttl\_attribute) | DynamoDB table ttl attribute | `string` | `"Expires"` | no |
 | <a name="input_dynamodb_ttl_enabled"></a> [dynamodb\_ttl\_enabled](#input\_dynamodb\_ttl\_enabled) | Whether ttl is enabled or disabled | `bool` | `true` | no |
-| <a name="input_enable_api_gateway"></a> [enable\_api\_gateway](#input\_enable\_api\_gateway) | allow to create api-gateway | `bool` | `false` | no |
+| <a name="input_enable_api_gateway"></a> [enable\_api\_gateway](#input\_enable\_api\_gateway) | Allow to create api-gateway | `bool` | `false` | no |
 | <a name="input_enable_datastore_module"></a> [enable\_datastore\_module](#input\_enable\_datastore\_module) | Enables the data store module that can provision data storage resources | `bool` | `false` | no |
 | <a name="input_enable_vpc"></a> [enable\_vpc](#input\_enable\_vpc) | Put lambda into the private VPC and default eks security group | `string` | `false` | no |
 | <a name="input_internal_entrypoint_config"></a> [internal\_entrypoint\_config](#input\_internal\_entrypoint\_config) | Map of configurations of internal entrypoints. | `map(any)` | n/a | yes |
@@ -138,11 +139,10 @@ A stand alone artifactory module has been provided as a stand alone module to ca
 | <a name="input_s3_bucket_namespace"></a> [s3\_bucket\_namespace](#input\_s3\_bucket\_namespace) | The namespace of the bucket - intention is to help avoid naming collisions | `string` | `""` | no |
 | <a name="input_s3_enable_versioning"></a> [s3\_enable\_versioning](#input\_s3\_enable\_versioning) | If versioning should be configured on the bucket | `bool` | `true` | no |
 | <a name="input_s3_tags"></a> [s3\_tags](#input\_s3\_tags) | Additional tags to be added to the s3 resources | `map` | `{}` | no |
-| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | stage name for the api gateway deployment | `string` | `"test"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags that are added to all resources in this module. | `map` | `{}` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group IDs associated with the Lambda function | `list(string)` | `[]` | no |
 | <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | List of subnet IDs associated with the Lambda function | `list(string)` | `[]` | no |
-| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route 53 zone id | `any` | n/a | yes |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route 53 hosted zone id | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -16,79 +16,134 @@ Given the stage of this module it is advised this not be used until further reso
 ## Artifactory Module
 A stand alone artifactory module has been provided as a stand alone module to cater for the creation of an artifactory bucket in a different AWS account. The [README](artifactory/README.md) contains more info.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 0.12.6, < 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lambda_datastore"></a> [lambda\_datastore](#module\_lambda\_datastore) | git::git@github.com:hyprnz/terraform-aws-data-storage-module?ref=2.0.1 |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
+| [aws_apigatewayv2_api.api_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api) | resource |
+| [aws_apigatewayv2_api_mapping.api_gateway_mapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api_mapping) | resource |
+| [aws_apigatewayv2_domain_name.api_gateway_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name) | resource |
+| [aws_apigatewayv2_stage.api_gateway_stage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage) | resource |
+| [aws_cloudwatch_event_rule.internal_entrypoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.lambda_internal_entrypoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.lambda_application_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.event_bridge_internal_entrypoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda_application_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.datastore_dynamodb_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.datastore_s3_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.event_bridge_internal_entrypoint_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_application_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.msk_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_default_read_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_event_source_mapping.msk_event_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_function.lambda_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_layer_version.runtime_dependencies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
+| [aws_lambda_permission.allow_apigateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.internal_entrypoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_route53_record.api_gateway_live](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.cert_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_iam_policy_document.event_bridge_internal_entrypoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_application_assume_role_statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_vpc_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| application\_name | Repo name of the lambda application. | `string` | n/a | yes |
-| application\_runtime | Lambda runtime for the application. | `string` | n/a | yes |
-| artifact\_bucket | Bucket that stores function artifacts. Includes layer dependencies. | `string` | n/a | yes |
-| artifact\_bucket\_key | File name key of the artifact to load. | `string` | n/a | yes |
-| internal\_entrypoint\_config | Map of configurations of internal entrypoints. | `map(any)` | n/a | yes |
-| lambda\_functions\_config | Map of functions and associated configurations. | `map(any)` | n/a | yes |
-| application\_env\_vars | Map of environment variables required by any function in the application. | `map(any)` | `{}` | no |
-| application\_memory | Memory allocated to all functions in the application. Defaults to `128`. | `number` | `128` | no |
-| application\_timeout | Timeout in seconds for all functions in the application. Defaults to `3`. | `number` | `3` | no |
-| aws\_cloudwatch\_log\_group\_retention\_in\_days | The retention period in days of all log group created for each function. Defaults to `30`. | `number` | `30` | no |
-| create\_dynamodb\_table | Whether or not to enable DynamoDB resources | `bool` | `false` | no |
-| create\_rds\_instance | Controls if an RDS instance should be provisioned and integrated with the Kubernetes deployment. | `bool` | `false` | no |
-| create\_s3\_bucket | Controls if an S3 bucket should be provisioned | `bool` | `false` | no |
-| datastore\_tags | Additional tags to add to all datastore resources | `map(string)` | `{}` | no |
-| dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | `list` | `[]` | no |
-| dynamodb\_autoscale\_max\_read\_capacity | DynamoDB autoscaling max read capacity | `number` | `20` | no |
-| dynamodb\_autoscale\_max\_write\_capacity | DynamoDB autoscaling max write capacity | `number` | `20` | no |
-| dynamodb\_autoscale\_min\_read\_capacity | DynamoDB autoscaling min read capacity | `number` | `5` | no |
-| dynamodb\_autoscale\_min\_write\_capacity | DynamoDB autoscaling min write capacity | `number` | `5` | no |
-| dynamodb\_autoscale\_read\_target | The target value (in %) for DynamoDB read autoscaling | `number` | `50` | no |
-| dynamodb\_autoscale\_write\_target | The target value (in %) for DynamoDB write autoscaling | `number` | `50` | no |
-| dynamodb\_billing\_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PROVISIONED"` | no |
-| dynamodb\_enable\_autoscaler | Whether or not to enable DynamoDB autoscaling | `bool` | `false` | no |
-| dynamodb\_enable\_encryption | Enable DynamoDB server-side encryption | `bool` | `true` | no |
-| dynamodb\_enable\_point\_in\_time\_recovery | Enable DynamoDB point in time recovery | `bool` | `true` | no |
-| dynamodb\_enable\_streams | Enable DynamoDB streams | `bool` | `false` | no |
-| dynamodb\_global\_secondary\_index\_map | Additional global secondary indexes in the form of a list of mapped values | `any` | `[]` | no |
-| dynamodb\_hash\_key | DynamoDB table Hash Key | `string` | `""` | no |
-| dynamodb\_hash\_key\_type | Hash Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | `string` | `"S"` | no |
-| dynamodb\_local\_secondary\_index\_map | Additional local secondary indexes in the form of a list of mapped values | `list` | `[]` | no |
-| dynamodb\_range\_key | DynamoDB table Range Key | `string` | `""` | no |
-| dynamodb\_range\_key\_type | Range Key type, which must be a scalar type: `S`, `N` or `B` for (S)tring, (N)umber or (B)inary data | `string` | `"S"` | no |
-| dynamodb\_stream\_view\_type | When an item in a table is modified, what information is written to the stream | `string` | `""` | no |
-| dynamodb\_table\_name | DynamoDB table name. Must be supplied if creating a dynamodb table | `string` | `""` | no |
-| dynamodb\_tags | Additional tags (e.g map(`BusinessUnit`,`XYX`) | `map` | `{}` | no |
-| dynamodb\_ttl\_attribute | DynamoDB table ttl attribute | `string` | `"Expires"` | no |
-| dynamodb\_ttl\_enabled | Whether ttl is enabled or disabled | `bool` | `true` | no |
-| enable\_datastore\_module | Enables the data store module that can provision data storage resources | `bool` | `false` | no |
-| layer\_artifact\_key | File name key of the layer artifact to load. | `string` | `""` | no |
-| rds\_allocated\_storage | Amount of storage allocated to RDS instance | `number` | `10` | no |
-| rds\_database\_name | The database name. Can only contain alphanumeric characters and cannot be a database reserved word | `string` | `""` | no |
-| rds\_enable\_performance\_insights | Controls the enabling of RDS Performance insights. Default to `true` | `bool` | `true` | no |
-| rds\_enable\_storage\_encryption | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
-| rds\_engine | The Database engine for the rds instance | `string` | `"postgres"` | no |
-| rds\_engine\_version | The version of the database engine | `number` | `11.4` | no |
-| rds\_identifier | Identifier of rds instance | `string` | `""` | no |
-| rds\_instance\_class | The instance type to use | `string` | `"db.t3.small"` | no |
-| rds\_iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
-| rds\_max\_allocated\_storage | The upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to `allocated_storage`. Must be greater than or equal to `allocated_storage` or `0` to disable Storage Autoscaling. | `number` | `0` | no |
-| rds\_monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
-| rds\_monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `""` | no |
-| rds\_password | RDS database password | `string` | `""` | no |
-| rds\_security\_group\_ids | A List of security groups to bind to the rds instance | `list(string)` | `[]` | no |
-| rds\_storage\_encryption\_kms\_key\_arn | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `""` | no |
-| rds\_subnet\_group | Subnet group for RDS instances | `string` | `""` | no |
-| rds\_tags | Additional tags for the RDS instance | `map(string)` | `{}` | no |
-| s3\_bucket\_name | The name of the bucket | `string` | `""` | no |
-| s3\_bucket\_namespace | The namespace of the bucket - intention is to help avoid naming collisions | `string` | `""` | no |
-| s3\_enable\_versioning | If versioning should be configured on the bucket | `bool` | `true` | no |
-| s3\_tags | Additional tags to be added to the s3 resources | `map` | `{}` | no |
-| tags | Additional tags that are added to all resources in this module. | `map` | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application_env_vars"></a> [application\_env\_vars](#input\_application\_env\_vars) | Map of environment variables required by any function in the application. | `map(any)` | `{}` | no |
+| <a name="input_application_memory"></a> [application\_memory](#input\_application\_memory) | Memory allocated to all functions in the application. Defaults to `128`. | `number` | `128` | no |
+| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Repo name of the lambda application. | `string` | n/a | yes |
+| <a name="input_application_runtime"></a> [application\_runtime](#input\_application\_runtime) | Lambda runtime for the application. | `string` | n/a | yes |
+| <a name="input_application_timeout"></a> [application\_timeout](#input\_application\_timeout) | Timeout in seconds for all functions in the application. Defaults to `3`. | `number` | `3` | no |
+| <a name="input_artifact_bucket"></a> [artifact\_bucket](#input\_artifact\_bucket) | Bucket that stores function artifacts. Includes layer dependencies. | `string` | n/a | yes |
+| <a name="input_artifact_bucket_key"></a> [artifact\_bucket\_key](#input\_artifact\_bucket\_key) | File name key of the artifact to load. | `string` | n/a | yes |
+| <a name="input_aws_cloudwatch_log_group_retention_in_days"></a> [aws\_cloudwatch\_log\_group\_retention\_in\_days](#input\_aws\_cloudwatch\_log\_group\_retention\_in\_days) | The retention period in days of all log group created for each function. Defaults to `30`. | `number` | `30` | no |
+| <a name="input_create_dynamodb_table"></a> [create\_dynamodb\_table](#input\_create\_dynamodb\_table) | Whether or not to enable DynamoDB resources | `bool` | `false` | no |
+| <a name="input_create_rds_instance"></a> [create\_rds\_instance](#input\_create\_rds\_instance) | Controls if an RDS instance should be provisioned and integrated with the Kubernetes deployment. | `bool` | `false` | no |
+| <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Controls if an S3 bucket should be provisioned | `bool` | `false` | no |
+| <a name="input_datastore_tags"></a> [datastore\_tags](#input\_datastore\_tags) | Additional tags to add to all datastore resources | `map(string)` | `{}` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The name of the domain | `any` | n/a | yes |
+| <a name="input_dynamodb_attributes"></a> [dynamodb\_attributes](#input\_dynamodb\_attributes) | Additional DynamoDB attributes in the form of a list of mapped values | `list` | `[]` | no |
+| <a name="input_dynamodb_autoscale_max_read_capacity"></a> [dynamodb\_autoscale\_max\_read\_capacity](#input\_dynamodb\_autoscale\_max\_read\_capacity) | DynamoDB autoscaling max read capacity | `number` | `20` | no |
+| <a name="input_dynamodb_autoscale_max_write_capacity"></a> [dynamodb\_autoscale\_max\_write\_capacity](#input\_dynamodb\_autoscale\_max\_write\_capacity) | DynamoDB autoscaling max write capacity | `number` | `20` | no |
+| <a name="input_dynamodb_autoscale_min_read_capacity"></a> [dynamodb\_autoscale\_min\_read\_capacity](#input\_dynamodb\_autoscale\_min\_read\_capacity) | DynamoDB autoscaling min read capacity | `number` | `5` | no |
+| <a name="input_dynamodb_autoscale_min_write_capacity"></a> [dynamodb\_autoscale\_min\_write\_capacity](#input\_dynamodb\_autoscale\_min\_write\_capacity) | DynamoDB autoscaling min write capacity | `number` | `5` | no |
+| <a name="input_dynamodb_autoscale_read_target"></a> [dynamodb\_autoscale\_read\_target](#input\_dynamodb\_autoscale\_read\_target) | The target value (in %) for DynamoDB read autoscaling | `number` | `50` | no |
+| <a name="input_dynamodb_autoscale_write_target"></a> [dynamodb\_autoscale\_write\_target](#input\_dynamodb\_autoscale\_write\_target) | The target value (in %) for DynamoDB write autoscaling | `number` | `50` | no |
+| <a name="input_dynamodb_billing_mode"></a> [dynamodb\_billing\_mode](#input\_dynamodb\_billing\_mode) | DynamoDB Billing mode. Can be PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PROVISIONED"` | no |
+| <a name="input_dynamodb_enable_autoscaler"></a> [dynamodb\_enable\_autoscaler](#input\_dynamodb\_enable\_autoscaler) | Whether or not to enable DynamoDB autoscaling | `bool` | `false` | no |
+| <a name="input_dynamodb_enable_encryption"></a> [dynamodb\_enable\_encryption](#input\_dynamodb\_enable\_encryption) | Enable DynamoDB server-side encryption | `bool` | `true` | no |
+| <a name="input_dynamodb_enable_point_in_time_recovery"></a> [dynamodb\_enable\_point\_in\_time\_recovery](#input\_dynamodb\_enable\_point\_in\_time\_recovery) | Enable DynamoDB point in time recovery | `bool` | `true` | no |
+| <a name="input_dynamodb_enable_streams"></a> [dynamodb\_enable\_streams](#input\_dynamodb\_enable\_streams) | Enable DynamoDB streams | `bool` | `false` | no |
+| <a name="input_dynamodb_global_secondary_index_map"></a> [dynamodb\_global\_secondary\_index\_map](#input\_dynamodb\_global\_secondary\_index\_map) | Additional global secondary indexes in the form of a list of mapped values | `any` | `[]` | no |
+| <a name="input_dynamodb_hash_key"></a> [dynamodb\_hash\_key](#input\_dynamodb\_hash\_key) | DynamoDB table Hash Key | `string` | `""` | no |
+| <a name="input_dynamodb_hash_key_type"></a> [dynamodb\_hash\_key\_type](#input\_dynamodb\_hash\_key\_type) | Hash Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | `string` | `"S"` | no |
+| <a name="input_dynamodb_local_secondary_index_map"></a> [dynamodb\_local\_secondary\_index\_map](#input\_dynamodb\_local\_secondary\_index\_map) | Additional local secondary indexes in the form of a list of mapped values | `list` | `[]` | no |
+| <a name="input_dynamodb_range_key"></a> [dynamodb\_range\_key](#input\_dynamodb\_range\_key) | DynamoDB table Range Key | `string` | `""` | no |
+| <a name="input_dynamodb_range_key_type"></a> [dynamodb\_range\_key\_type](#input\_dynamodb\_range\_key\_type) | Range Key type, which must be a scalar type: `S`, `N` or `B` for (S)tring, (N)umber or (B)inary data | `string` | `"S"` | no |
+| <a name="input_dynamodb_stream_view_type"></a> [dynamodb\_stream\_view\_type](#input\_dynamodb\_stream\_view\_type) | When an item in a table is modified, what information is written to the stream | `string` | `""` | no |
+| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | DynamoDB table name. Must be supplied if creating a dynamodb table | `string` | `""` | no |
+| <a name="input_dynamodb_tags"></a> [dynamodb\_tags](#input\_dynamodb\_tags) | Additional tags (e.g map(`BusinessUnit`,`XYX`) | `map` | `{}` | no |
+| <a name="input_dynamodb_ttl_attribute"></a> [dynamodb\_ttl\_attribute](#input\_dynamodb\_ttl\_attribute) | DynamoDB table ttl attribute | `string` | `"Expires"` | no |
+| <a name="input_dynamodb_ttl_enabled"></a> [dynamodb\_ttl\_enabled](#input\_dynamodb\_ttl\_enabled) | Whether ttl is enabled or disabled | `bool` | `true` | no |
+| <a name="input_enable_api_gateway"></a> [enable\_api\_gateway](#input\_enable\_api\_gateway) | allow to create api-gateway | `bool` | `false` | no |
+| <a name="input_enable_datastore_module"></a> [enable\_datastore\_module](#input\_enable\_datastore\_module) | Enables the data store module that can provision data storage resources | `bool` | `false` | no |
+| <a name="input_enable_vpc"></a> [enable\_vpc](#input\_enable\_vpc) | Put lambda into the private VPC and default eks security group | `string` | `false` | no |
+| <a name="input_internal_entrypoint_config"></a> [internal\_entrypoint\_config](#input\_internal\_entrypoint\_config) | Map of configurations of internal entrypoints. | `map(any)` | n/a | yes |
+| <a name="input_lambda_functions_config"></a> [lambda\_functions\_config](#input\_lambda\_functions\_config) | Map of functions and associated configurations. | `map(any)` | n/a | yes |
+| <a name="input_layer_artifact_key"></a> [layer\_artifact\_key](#input\_layer\_artifact\_key) | File name key of the layer artifact to load. | `string` | `""` | no |
+| <a name="input_msk_arn"></a> [msk\_arn](#input\_msk\_arn) | the MSK source arn for all lambda requires MSK | `string` | `""` | no |
+| <a name="input_msk_event_source_config"></a> [msk\_event\_source\_config](#input\_msk\_event\_source\_config) | Map of configurations of MSK event source for each lambda | `map(any)` | `{}` | no |
+| <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage) | Amount of storage allocated to RDS instance | `number` | `10` | no |
+| <a name="input_rds_database_name"></a> [rds\_database\_name](#input\_rds\_database\_name) | The database name. Can only contain alphanumeric characters and cannot be a database reserved word | `string` | `""` | no |
+| <a name="input_rds_enable_performance_insights"></a> [rds\_enable\_performance\_insights](#input\_rds\_enable\_performance\_insights) | Controls the enabling of RDS Performance insights. Default to `true` | `bool` | `true` | no |
+| <a name="input_rds_enable_storage_encryption"></a> [rds\_enable\_storage\_encryption](#input\_rds\_enable\_storage\_encryption) | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
+| <a name="input_rds_engine"></a> [rds\_engine](#input\_rds\_engine) | The Database engine for the rds instance | `string` | `"postgres"` | no |
+| <a name="input_rds_engine_version"></a> [rds\_engine\_version](#input\_rds\_engine\_version) | The version of the database engine | `number` | `11.4` | no |
+| <a name="input_rds_identifier"></a> [rds\_identifier](#input\_rds\_identifier) | Identifier of rds instance | `string` | `""` | no |
+| <a name="input_rds_instance_class"></a> [rds\_instance\_class](#input\_rds\_instance\_class) | The instance type to use | `string` | `"db.t3.small"` | no |
+| <a name="input_rds_iops"></a> [rds\_iops](#input\_rds\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| <a name="input_rds_max_allocated_storage"></a> [rds\_max\_allocated\_storage](#input\_rds\_max\_allocated\_storage) | The upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to `allocated_storage`. Must be greater than or equal to `allocated_storage` or `0` to disable Storage Autoscaling. | `number` | `0` | no |
+| <a name="input_rds_monitoring_interval"></a> [rds\_monitoring\_interval](#input\_rds\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
+| <a name="input_rds_monitoring_role_arn"></a> [rds\_monitoring\_role\_arn](#input\_rds\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `""` | no |
+| <a name="input_rds_password"></a> [rds\_password](#input\_rds\_password) | RDS database password | `string` | `""` | no |
+| <a name="input_rds_security_group_ids"></a> [rds\_security\_group\_ids](#input\_rds\_security\_group\_ids) | A List of security groups to bind to the rds instance | `list(string)` | `[]` | no |
+| <a name="input_rds_storage_encryption_kms_key_arn"></a> [rds\_storage\_encryption\_kms\_key\_arn](#input\_rds\_storage\_encryption\_kms\_key\_arn) | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `""` | no |
+| <a name="input_rds_subnet_group"></a> [rds\_subnet\_group](#input\_rds\_subnet\_group) | Subnet group for RDS instances | `string` | `""` | no |
+| <a name="input_rds_tags"></a> [rds\_tags](#input\_rds\_tags) | Additional tags for the RDS instance | `map(string)` | `{}` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the bucket | `string` | `""` | no |
+| <a name="input_s3_bucket_namespace"></a> [s3\_bucket\_namespace](#input\_s3\_bucket\_namespace) | The namespace of the bucket - intention is to help avoid naming collisions | `string` | `""` | no |
+| <a name="input_s3_enable_versioning"></a> [s3\_enable\_versioning](#input\_s3\_enable\_versioning) | If versioning should be configured on the bucket | `bool` | `true` | no |
+| <a name="input_s3_tags"></a> [s3\_tags](#input\_s3\_tags) | Additional tags to be added to the s3 resources | `map` | `{}` | no |
+| <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | stage name for the api gateway deployment | `string` | `"test"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags that are added to all resources in this module. | `map` | `{}` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group IDs associated with the Lambda function | `list(string)` | `[]` | no |
+| <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | List of subnet IDs associated with the Lambda function | `list(string)` | `[]` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route 53 zone id | `any` | n/a | yes |
 
 ## Outputs
 
-No output.
-
+No outputs.

--- a/acm.tf
+++ b/acm.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = {
+    Environment = "test"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.zone_id
+}

--- a/acm.tf
+++ b/acm.tf
@@ -1,10 +1,8 @@
 resource "aws_acm_certificate" "cert" {
+  count             = var.enable_api_gateway ? 1 : 0
   domain_name       = var.domain_name
   validation_method = "DNS"
-
-  tags = {
-    Environment = "test"
-  }
+  tags              = merge({ Name = format("%s-%s", var.application_name, "acm certificate") }, { "Lambda Application" = var.application_name }, var.tags)
 
   lifecycle {
     create_before_destroy = true
@@ -12,13 +10,14 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = aws_acm_certificate.cert.arn
+  count                   = var.enable_api_gateway ? 1 : 0
+  certificate_arn         = aws_acm_certificate.cert[0].arn
   validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
 
 resource "aws_route53_record" "cert_validation" {
   for_each = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -1,0 +1,20 @@
+// to use the api-gateway, a service lambda must in lambda_application
+resource "aws_apigatewayv2_api" "api_gateway" {
+  name          = var.application_name
+  protocol_type = "HTTP"
+  route_key     = "$default"
+  target        = aws_lambda_function.lambda_application["service"].arn
+  count         = var.enable_api_gateway ? 1 : 0
+}
+
+resource "aws_lambda_permission" "allow_apigateway" {
+  statement_id  = "AllowExecutionFromApiGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_application["service"].function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api_gateway.0.execution_arn}/*"
+  count         = var.enable_api_gateway ? 1 : 0
+}
+
+# todo aws_apigatewayv2_authorizer: will be helpful to reduce duplicated work
+# todo aws_apigatewayv2_domain_name: need domain and cert setup

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -5,7 +5,7 @@ resource "aws_apigatewayv2_api" "api_gateway" {
   protocol_type = "HTTP"
   route_key     = "$default"
   target        = aws_lambda_function.lambda_application["service"].arn
-  tags          = merge({ Name = format("%s-%s", var.application_name, "api_gateway")}, { "Lambda Application" = var.application_name }, var.tags)
+  tags          = merge({ Name = format("%s-%s", var.application_name, "api_gateway") }, { "Lambda Application" = var.application_name }, var.tags)
 }
 
 resource "aws_lambda_permission" "allow_apigateway" {

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -1,20 +1,20 @@
 // to use the api-gateway, a service lambda must in lambda_application
 resource "aws_apigatewayv2_api" "api_gateway" {
+  count         = var.enable_api_gateway ? 1 : 0
   name          = var.application_name
   protocol_type = "HTTP"
   route_key     = "$default"
   target        = aws_lambda_function.lambda_application["service"].arn
-  count         = var.enable_api_gateway ? 1 : 0
+  tags          = merge({ Name = format("%s-%s", var.application_name, "api_gateway")}, { "Lambda Application" = var.application_name }, var.tags)
 }
 
 resource "aws_lambda_permission" "allow_apigateway" {
+  count         = var.enable_api_gateway ? 1 : 0
   statement_id  = "AllowExecutionFromApiGateway"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda_application["service"].function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.api_gateway.0.execution_arn}/*"
-  count         = var.enable_api_gateway ? 1 : 0
+  source_arn    = "${aws_apigatewayv2_api.api_gateway[0].execution_arn}/*"
 }
 
 # todo aws_apigatewayv2_authorizer: will be helpful to reduce duplicated work
-# todo aws_apigatewayv2_domain_name: need domain and cert setup

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -17,4 +17,11 @@ resource "aws_lambda_permission" "allow_apigateway" {
   source_arn    = "${aws_apigatewayv2_api.api_gateway[0].execution_arn}/*"
 }
 
+resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
+  count       = var.enable_api_gateway ? 1 : 0
+  api_id      = aws_apigatewayv2_api.api_gateway[0].id
+  domain_name = aws_apigatewayv2_domain_name.api_gateway_domain[0].id
+  stage       = "$default"
+}
+
 # todo aws_apigatewayv2_authorizer: will be helpful to reduce duplicated work

--- a/iam.tf
+++ b/iam.tf
@@ -49,7 +49,6 @@ data "aws_iam_policy_document" "lambda_vpc_document" {
   }
 }
 
-
 resource "aws_iam_role" "lambda_application_execution_role" {
   name = format("ExecutionRole-Lambda-%s", var.application_name)
 
@@ -102,4 +101,10 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc" {
   count       = var.enable_vpc ? 1 : 0
   role       = aws_iam_role.lambda_application_execution_role.name
   policy_arn = aws_iam_policy.lambda_vpc[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "msk_access_policy" {
+  count      = length(keys(var.msk_event_source_config)) > 0 ? 1 : 0
+  role       = aws_iam_role.lambda_application_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -94,11 +94,11 @@ resource "aws_iam_policy" "lambda_vpc" {
   count       = var.enable_vpc ? 1 : 0
   name        = "LambdaApplication-${replace(var.application_name, "/-| |_/", "")}-LambdaVPC"
   description = "Grants permissions to access VPC"
-  policy = data.aws_iam_policy_document.lambda_vpc_document.json
+  policy      = data.aws_iam_policy_document.lambda_vpc_document.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_vpc" {
-  count       = var.enable_vpc ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   role       = aws_iam_role.lambda_application_execution_role.name
   policy_arn = aws_iam_policy.lambda_vpc[0].arn
 }

--- a/iam.tf
+++ b/iam.tf
@@ -92,12 +92,14 @@ resource "aws_iam_role_policy_attachment" "datastore_dynamodb_access_policy" {
 }
 
 resource "aws_iam_policy" "lambda_vpc" {
+  count       = var.enable_vpc ? 1 : 0
   name        = "LambdaApplication-${replace(var.application_name, "/-| |_/", "")}-LambdaVPC"
   description = "Grants permissions to access VPC"
   policy = data.aws_iam_policy_document.lambda_vpc_document.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  count       = var.enable_vpc ? 1 : 0
   role       = aws_iam_role.lambda_application_execution_role.name
-  policy_arn = aws_iam_policy.lambda_vpc.arn
+  policy_arn = aws_iam_policy.lambda_vpc[0].arn
 }

--- a/iam.tf
+++ b/iam.tf
@@ -30,6 +30,26 @@ data "aws_iam_policy_document" "event_bridge_internal_entrypoint" {
   }
 }
 
+data "aws_iam_policy_document" "lambda_vpc_document" {
+  statement {
+    sid = "LambdaVPC"
+
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+  }
+}
+
+
 resource "aws_iam_role" "lambda_application_execution_role" {
   name = format("ExecutionRole-Lambda-%s", var.application_name)
 
@@ -69,4 +89,15 @@ resource "aws_iam_role_policy_attachment" "datastore_dynamodb_access_policy" {
   count      = var.enable_datastore_module && var.create_dynamodb_table ? 1 : 0
   role       = aws_iam_role.lambda_application_execution_role.name
   policy_arn = module.lambda_datastore.dynamodb_table_policy_arn
+}
+
+resource "aws_iam_policy" "lambda_vpc" {
+  name        = "LambdaApplication-${replace(var.application_name, "/-| |_/", "")}-LambdaVPC"
+  description = "Grants permissions to access VPC"
+  policy = data.aws_iam_policy_document.lambda_vpc_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  role       = aws_iam_role.lambda_application_execution_role.name
+  policy_arn = aws_iam_policy.lambda_vpc.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -36,13 +36,13 @@ resource "aws_lambda_function" "lambda_application" {
   timeout     = var.application_timeout
 
   layers = [aws_lambda_layer_version.runtime_dependencies.arn]
-
+  
   environment {
     variables = merge({ APP_NAME = var.application_name }, local.datastore_env_vars, var.application_env_vars)
   }
 
   dynamic "vpc_config" {
-    for_each = var.enable_vpc ? [true] : []
+    for_each = each.value.enable_vpc ? [true] : []
     content {
       subnet_ids         = var.vpc_subnet_ids
       security_group_ids = var.vpc_security_group_ids

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "lambda_application" {
   timeout     = var.application_timeout
 
   layers = [aws_lambda_layer_version.runtime_dependencies.arn]
-  
+
   environment {
     variables = merge({ APP_NAME = var.application_name }, local.datastore_env_vars, var.application_env_vars)
   }
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "lambda_application" {
     content {
       subnet_ids         = var.vpc_subnet_ids
       security_group_ids = var.vpc_security_group_ids
-      }
+    }
   }
 
   tags = merge({ Name = format("%s-%s", var.application_name, each.value.name) }, { "Lambda Application" = var.application_name }, var.tags)
@@ -82,5 +82,4 @@ resource "aws_lambda_layer_version" "runtime_dependencies" {
 
   compatible_runtimes = [var.application_runtime]
 }
-
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,14 @@ resource "aws_lambda_function" "lambda_application" {
     variables = merge({ APP_NAME = var.application_name }, local.datastore_env_vars, var.application_env_vars)
   }
 
+  dynamic "vpc_config" {
+    for_each = var.enable_vpc ? [true] : []
+    content {
+      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids = var.vpc_security_group_ids
+      }
+  }
+
   tags = merge({ Name = format("%s-%s", var.application_name, each.value.name) }, { "Lambda Application" = var.application_name }, var.tags)
 }
 
@@ -73,7 +81,6 @@ resource "aws_lambda_layer_version" "runtime_dependencies" {
   description = "External modules and application shared code"
 
   compatible_runtimes = [var.application_runtime]
-
 }
 
 

--- a/msk.tf
+++ b/msk.tf
@@ -1,0 +1,9 @@
+resource "aws_lambda_event_source_mapping" "msk_event_source" {
+  for_each = var.msk_event_source_config
+
+  event_source_arn  = var.msk_arn
+  function_name     = aws_lambda_function.lambda_application[each.key].arn
+  topics            = each.value.topics
+  starting_position = each.value.starting_position
+  batch_size        = each.value.batch_size
+}

--- a/route53.tf
+++ b/route53.tf
@@ -25,18 +25,3 @@ resource "aws_route53_record" "api_gateway_live" {
     evaluate_target_health = false
   }
 }
-
-resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
-  count       = var.enable_api_gateway ? 1 : 0
-  api_id      = aws_apigatewayv2_api.api_gateway[0].id
-  domain_name = aws_apigatewayv2_domain_name.api_gateway_domain[0].id
-  stage       = aws_apigatewayv2_stage.api_gateway_stage[0].id
-}
-
-resource "aws_apigatewayv2_stage" "api_gateway_stage" {
-  count       = var.enable_api_gateway ? 1 : 0
-  api_id      = aws_apigatewayv2_api.api_gateway[0].id
-  name        = var.api_gateway_stage_name
-  auto_deploy = true
-  tags        = merge({ Name = format("%s-%s", var.application_name, "api_gateway_stage") }, { "Lambda Application" = var.application_name }, var.tags)
-}

--- a/route53.tf
+++ b/route53.tf
@@ -29,6 +29,6 @@ resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
 
 resource "aws_apigatewayv2_stage" "api_gateway_stage" {
   api_id = aws_apigatewayv2_api.api_gateway[0].id
-  name   = "test"
+  name   = var.stage_name
   auto_deploy = true
 }

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_domain_name" "api_gateway_domain" {
+  depends_on = [aws_acm_certificate_validation.cert]  
+  domain_name = var.domain_name
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.cert.arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_route53_record" "api_gateway_live" {
+  name    = var.domain_name
+  type    = "A"
+  zone_id = var.zone_id
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api_gateway_domain.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api_gateway_domain.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
+  api_id      = aws_apigatewayv2_api.api_gateway[0].id
+  domain_name = aws_apigatewayv2_domain_name.api_gateway_domain.id
+  stage       = aws_apigatewayv2_stage.api_gateway_stage.id
+}
+
+resource "aws_apigatewayv2_stage" "api_gateway_stage" {
+  api_id = aws_apigatewayv2_api.api_gateway[0].id
+  name   = "test"
+  auto_deploy = true
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,34 +1,42 @@
 resource "aws_apigatewayv2_domain_name" "api_gateway_domain" {
-  depends_on  = [aws_acm_certificate_validation.cert]
+  count       = var.enable_api_gateway ? 1 : 0
   domain_name = var.domain_name
 
   domain_name_configuration {
-    certificate_arn = aws_acm_certificate.cert.arn
+    certificate_arn = aws_acm_certificate.cert[0].arn
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }
+
+  tags = merge({ Name = format("%s-%s", var.application_name, "api_gateway_domain") }, { "Lambda Application" = var.application_name }, var.tags)
+
+  depends_on = [aws_acm_certificate_validation.cert]
 }
 
 resource "aws_route53_record" "api_gateway_live" {
+  count   = var.enable_api_gateway ? 1 : 0
   name    = var.domain_name
   type    = "A"
   zone_id = var.zone_id
 
   alias {
-    name                   = aws_apigatewayv2_domain_name.api_gateway_domain.domain_name_configuration[0].target_domain_name
-    zone_id                = aws_apigatewayv2_domain_name.api_gateway_domain.domain_name_configuration[0].hosted_zone_id
+    name                   = aws_apigatewayv2_domain_name.api_gateway_domain[0].domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api_gateway_domain[0].domain_name_configuration[0].hosted_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
+  count       = var.enable_api_gateway ? 1 : 0
   api_id      = aws_apigatewayv2_api.api_gateway[0].id
-  domain_name = aws_apigatewayv2_domain_name.api_gateway_domain.id
-  stage       = aws_apigatewayv2_stage.api_gateway_stage.id
+  domain_name = aws_apigatewayv2_domain_name.api_gateway_domain[0].id
+  stage       = aws_apigatewayv2_stage.api_gateway_stage[0].id
 }
 
 resource "aws_apigatewayv2_stage" "api_gateway_stage" {
+  count       = var.enable_api_gateway ? 1 : 0
   api_id      = aws_apigatewayv2_api.api_gateway[0].id
-  name        = var.stage_name
+  name        = var.api_gateway_stage_name
   auto_deploy = true
+  tags        = merge({ Name = format("%s-%s", var.application_name, "api_gateway_stage") }, { "Lambda Application" = var.application_name }, var.tags)
 }

--- a/route53.tf
+++ b/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_apigatewayv2_domain_name" "api_gateway_domain" {
-  depends_on = [aws_acm_certificate_validation.cert]  
+  depends_on  = [aws_acm_certificate_validation.cert]
   domain_name = var.domain_name
 
   domain_name_configuration {
@@ -28,7 +28,7 @@ resource "aws_apigatewayv2_api_mapping" "api_gateway_mapping" {
 }
 
 resource "aws_apigatewayv2_stage" "api_gateway_stage" {
-  api_id = aws_apigatewayv2_api.api_gateway[0].id
-  name   = var.stage_name
+  api_id      = aws_apigatewayv2_api.api_gateway[0].id
+  name        = var.stage_name
   auto_deploy = true
 }

--- a/vars.tf
+++ b/vars.tf
@@ -379,5 +379,5 @@ variable "domain_name" {
 
 variable "stage_name" {
   description = "stage name for the api gateway deployment"
-  default = "test"
+  default     = "test"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -376,3 +376,8 @@ variable "zone_id" {
 variable "domain_name" {
   description = "The name of the domain"
 }
+
+variable "stage_name" {
+  description = "stage name for the api gateway deployment"
+  default = "test"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -378,9 +378,3 @@ variable "domain_name" {
   type        = string
   description = "The custom domain name for api gateway that points to lambda application"
 }
-
-variable "api_gateway_stage_name" {
-  type        = string
-  description = "Stage name for the api gateway deployment"
-  default     = "test"
-}

--- a/vars.tf
+++ b/vars.tf
@@ -46,6 +46,25 @@ variable "application_timeout" {
   default     = 3
 }
 
+variable "enable_vpc" {
+  type        = string
+  description = "Put lambda into the private VPC and default eks security group"
+  default     = false
+}
+
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs associated with the Lambda function"
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs associated with the Lambda function"
+  default     = []
+}
+
 variable "layer_artifact_key" {
   type        = string
   description = "File name key of the layer artifact to load."
@@ -338,3 +357,10 @@ variable "enable_api_gateway" {
   default     = false
 }
 
+variable "zone_id" {
+  description = "Route 53 zone id"
+}
+
+variable "domain_name" {
+  description = "The name of the domain"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -18,6 +18,18 @@ variable "internal_entrypoint_config" {
   description = "Map of configurations of internal entrypoints."
 }
 
+variable "msk_arn" {
+  type        = string
+  description = "the MSK source arn for all lambda requires MSK"
+  default     = ""
+}
+
+variable "msk_event_source_config" {
+  type        = map(any)
+  description = "Map of configurations of MSK event source for each lambda"
+  default     = {}
+}
+
 variable "artifact_bucket" {
   type        = string
   description = "Bucket that stores function artifacts. Includes layer dependencies."

--- a/vars.tf
+++ b/vars.tf
@@ -332,4 +332,9 @@ variable "s3_tags" {
   default     = {}
 }
 
+variable "enable_api_gateway" {
+  type        = bool
+  description = "allow to create api-gateway"
+  default     = false
+}
 

--- a/vars.tf
+++ b/vars.tf
@@ -365,19 +365,22 @@ variable "s3_tags" {
 
 variable "enable_api_gateway" {
   type        = bool
-  description = "allow to create api-gateway"
+  description = "Allow to create api-gateway"
   default     = false
 }
 
 variable "zone_id" {
-  description = "Route 53 zone id"
+  type        = string
+  description = "Route 53 hosted zone id"
 }
 
 variable "domain_name" {
-  description = "The name of the domain"
+  type        = string
+  description = "The custom domain name for api gateway that points to lambda application"
 }
 
-variable "stage_name" {
-  description = "stage name for the api gateway deployment"
+variable "api_gateway_stage_name" {
+  type        = string
+  description = "Stage name for the api gateway deployment"
   default     = "test"
 }


### PR DESCRIPTION
This release allows us to set up a custom domain(including certificate) for API gateway which points to the lambda function.

Allows each Lambda function to have the ability to enable vpc config.

Allows Kafka data source to be pulled optionally.